### PR TITLE
Fix node version in Action and update Action name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ If you have any questions please reach out to us on [Discord](https://chat.dmno.
 
 ## Installation
 
-You'll need, at minimum, node 22 and pnpm 10+ installed.
+You'll need, at minimum, node 24 and pnpm 10+ installed.
 
 We recommend using [fnm](https://github.com/Schniz/fnm) to manage node versions. If you use `fnm` with [`corepack`](https://github.com/nodejs/corepack) you can run `corepack enable` to enable pnpm and you should be good to go.
 
@@ -31,4 +31,3 @@ pnpm test
 ## Varlock
 
 For more information on varlock, please see the main [varlock repository](https://github.com/dmno-dev/varlock).
-

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Load environment variables
-        uses: dmno-dev/varlock-github-action@v1
-      
+        uses: dmno-dev/varlock-action@v0.0.1    
+
       - name: Use loaded variables
         run: |
           echo "Database URL: $DATABASE_URL"
@@ -50,13 +50,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Set environment flag
         run: echo "APP_ENV=production" >> $GITHUB_ENV
       
       - name: Load environment variables
-        uses: dmno-dev/varlock-github-action@v1
+        uses: dmno-dev/varlock-action@v0.0.1
         with:
           working-directory: './config'
           show-summary: 'true'
@@ -139,7 +139,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Load environment variables
-        uses: dmno-dev/varlock-github-action@v1
+        uses: dmno-dev/varlock-action@v0.0.1
       
       - name: Run tests
         run: npm test
@@ -176,7 +176,7 @@ jobs:
           fi
       
       - name: Load environment variables
-        uses: dmno-dev/varlock-github-action@v1
+        uses: dmno-dev/varlock-action@v0.0.1
         with:
           show-summary: 'true'
       
@@ -205,7 +205,7 @@ jobs:
         run: echo "APP_ENV=production" >> $GITHUB_ENV
       
       - name: Load environment variables
-        uses: dmno-dev/varlock-github-action@v1
+        uses: dmno-dev/varlock-action@v0.0.1
         with:
           working-directory: './config/environments'
       
@@ -228,7 +228,7 @@ The action provides comprehensive error handling:
 
 ```yaml
 - name: Load environment variables
-  uses: dmno-dev/varlock-github-action@v1
+  uses: dmno-dev/varlock-action@v0.0.1
   with:
     fail-on-error: 'false'  # Continue on validation errors
     show-summary: 'true'
@@ -322,4 +322,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
 
 ## License
 
-MIT License - see the [varlock repository](https://github.com/dmno-dev/varlock) for details. 
+MIT License - see the [varlock repository](https://github.com/dmno-dev/varlock) for details.

--- a/action.yml
+++ b/action.yml
@@ -26,14 +26,11 @@ inputs:
 outputs:
   summary:
     description: 'Summary of loaded environment variables'
-    value: ${{ steps.varlock.outputs.summary }}
   error-count:
     description: 'Number of validation errors found'
-    value: ${{ steps.varlock.outputs.error-count }}
   json-env:
-    description: 'JSON blob containing all environment variables (only available when output-format is "json"). This will contain all environment variables, including sensitive ones. Be careful.'
-    value: ${{ steps.varlock.outputs.json-env }}
+    description: "JSON blob containing all environment variables (only available when output-format is 'json'). This will contain all environment variables, including sensitive ones. Be careful."
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "author": "dmno-dev",
   "license": "MIT",
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "peerDependencies": {
     "varlock": "^0.0.11"


### PR DESCRIPTION
Currently this GitHub Action fails because it includes an invalid node version (22). In this PR I've update the node version in the `action.yaml` as well as the `README.md` and `package.json`. In addition, the name of the Action listed in the documentation does not match the name listed on the Actions Marketplace. I've updated that as well. Finally, `value` is not a valid property for outputs in the [Workflow Syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax?search-overlay-input=runs). I've removed that property as the output is set in `src/index.js`. 